### PR TITLE
Fix payroll date overlap calculation

### DIFF
--- a/backend/internal/payrollcalc/dateutils.go
+++ b/backend/internal/payrollcalc/dateutils.go
@@ -1,0 +1,82 @@
+package payrollcalc
+
+import (
+	"errors"
+	"math"
+	"time"
+)
+
+// MonthStartEnd returns the first and last day of the given month in the local timezone.
+func MonthStartEnd(year, month int) (time.Time, time.Time, error) {
+	if year < 1 || month < 1 || month > 12 {
+		return time.Time{}, time.Time{}, errors.New("invalid payroll period")
+	}
+	loc := time.Local
+	start := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, loc)
+	end := start.AddDate(0, 1, -1)
+	return start, end, nil
+}
+
+// OverlapDays returns the number of worked days within the payroll period and total days in the period.
+func OverlapDays(hire time.Time, end *time.Time, periodStart, periodEnd time.Time) (worked, total int) {
+	loc := periodStart.Location()
+	if loc == nil {
+		loc = time.Local
+	}
+
+	startPeriod := normalizeDate(periodStart, loc)
+	endPeriod := normalizeDate(periodEnd, loc)
+	if endPeriod.Before(startPeriod) {
+		return 0, 0
+	}
+
+	total = int(endPeriod.Sub(startPeriod).Hours()/24) + 1
+	if total < 0 {
+		total = 0
+	}
+
+	hireDate := normalizeDate(hire, loc)
+	start := startPeriod
+	if hireDate.After(start) {
+		start = hireDate
+	}
+
+	var last time.Time
+	if end != nil {
+		endDate := normalizeDate(*end, loc)
+		if endDate.Before(startPeriod) {
+			return 0, total
+		}
+		last = endPeriod
+		if endDate.Before(last) {
+			last = endDate
+		}
+	} else {
+		last = endPeriod
+	}
+
+	if last.Before(start) {
+		return 0, total
+	}
+
+	worked = int(last.Sub(start).Hours()/24) + 1
+	if worked < 0 {
+		worked = 0
+	}
+	return worked, total
+}
+
+// Round2 rounds a float to two decimal places.
+func Round2(n float64) float64 {
+	return math.Round(n*100) / 100
+}
+
+func normalizeDate(t time.Time, loc *time.Location) time.Time {
+	if loc == nil {
+		loc = time.Local
+	}
+	if t.IsZero() {
+		return time.Time{}
+	}
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc)
+}

--- a/backend/internal/payrollcalc/dateutils_test.go
+++ b/backend/internal/payrollcalc/dateutils_test.go
@@ -1,0 +1,59 @@
+package payrollcalc
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMonthStartEnd(t *testing.T) {
+	start, end, err := MonthStartEnd(2025, 9)
+	if err != nil {
+		t.Fatalf("MonthStartEnd returned error: %v", err)
+	}
+	if start.Day() != 1 || start.Month() != time.September || start.Year() != 2025 {
+		t.Fatalf("unexpected start date: %v", start)
+	}
+	if end.Day() != 30 || end.Month() != time.September || end.Year() != 2025 {
+		t.Fatalf("unexpected end date: %v", end)
+	}
+}
+
+func TestMonthStartEndInvalid(t *testing.T) {
+	if _, _, err := MonthStartEnd(2025, 13); err == nil {
+		t.Fatal("expected error for invalid month")
+	}
+}
+
+func TestOverlapDaysHandlesTimezoneMismatch(t *testing.T) {
+	// Payroll period created in UTC while employee dates are stored in a local timezone
+	ps := time.Date(2025, time.September, 1, 0, 0, 0, 0, time.UTC)
+	pe := time.Date(2025, time.September, 30, 0, 0, 0, 0, time.UTC)
+
+	loc := time.FixedZone("Asia/Bangkok", 7*3600)
+	hire := time.Date(2025, time.September, 1, 0, 0, 0, 0, loc)
+	term := time.Date(2025, time.September, 15, 0, 0, 0, 0, loc)
+
+	worked, total := OverlapDays(hire, &term, ps, pe)
+	if total != 30 {
+		t.Fatalf("expected total days 30, got %d", total)
+	}
+	if worked != 15 {
+		t.Fatalf("expected worked days 15, got %d", worked)
+	}
+}
+
+func TestOverlapDaysTerminatedBeforePeriod(t *testing.T) {
+	ps := time.Date(2025, time.October, 1, 0, 0, 0, 0, time.UTC)
+	pe := time.Date(2025, time.October, 31, 0, 0, 0, 0, time.UTC)
+
+	hire := time.Date(2025, time.September, 1, 0, 0, 0, 0, time.UTC)
+	term := time.Date(2025, time.September, 20, 0, 0, 0, 0, time.UTC)
+
+	worked, total := OverlapDays(hire, &term, ps, pe)
+	if worked != 0 {
+		t.Fatalf("expected worked days 0, got %d", worked)
+	}
+	if total != 31 {
+		t.Fatalf("expected total days 31, got %d", total)
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared payroll calculation helper package that normalizes period and employment dates
- update the payroll service and handler to use the shared helpers for prorating salaries and rounding
- cover the date overlap edge cases with new unit tests

## Testing
- `cd backend && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ebd2258ac48322b43a06c164147c0b